### PR TITLE
Changed all instances of .col-xs-12 to .col-xxs-12.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/attachment/attachment.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/attachment/attachment.twig
@@ -25,7 +25,7 @@
   <div class="civic-attachment {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-12">
           <div class="civic-attachment__content">
             {% block content_top %}
               {% if content_top is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/attachment/attachment.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/attachment/attachment.twig
@@ -25,7 +25,7 @@
   <div class="civic-attachment {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-12">
+        <div class="col-xxs-12">
           <div class="civic-attachment__content">
             {% block content_top %}
               {% if content_top is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-content/basic-content.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-content/basic-content.twig
@@ -20,7 +20,7 @@
     {% if is_contained %}
       <div class="container">
         <div class="row">
-          <div class="col-xs-12">
+          <div class="col-12">
             {% endif %}
               {{ content|raw }}
             {% if is_contained %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-content/basic-content.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-content/basic-content.twig
@@ -20,7 +20,7 @@
     {% if is_contained %}
       <div class="container">
         <div class="row">
-          <div class="col-12">
+          <div class="col-xxs-12">
             {% endif %}
               {{ content|raw }}
             {% if is_contained %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-filter/basic-filter.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-filter/basic-filter.twig
@@ -19,7 +19,7 @@
 <div class="civic-basic-filter {{ modifier_class }}" data-component-name="civic-basic-filter">
   <div class="container">
     <div class="row">
-      <div class="col-12">
+      <div class="col-xxs-12">
         <div class="civic-basic-filter__list">
           {% block filters %}
             {% for item in items %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-filter/basic-filter.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/basic-filter/basic-filter.twig
@@ -19,7 +19,7 @@
 <div class="civic-basic-filter {{ modifier_class }}" data-component-name="civic-basic-filter">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12">
+      <div class="col-12">
         <div class="civic-basic-filter__list">
           {% block filters %}
             {% for item in items %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/map/map.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/map/map.twig
@@ -19,7 +19,7 @@
   <div class="civic-map {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-12">
           {% block map %}
             <div class="civic-map__canvas">
               {% set attributes = 'allowfullscreen data-chromatic="ignore"' %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/map/map.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/map/map.twig
@@ -19,7 +19,7 @@
   <div class="civic-map {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-12">
+        <div class="col-xxs-12">
           {% block map %}
             <div class="civic-map__canvas">
               {% set attributes = 'allowfullscreen data-chromatic="ignore"' %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/next-steps/next-steps.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/next-steps/next-steps.twig
@@ -21,7 +21,7 @@
   <a class="civic-next-steps {{ modifier_class }}" href={{ url }}>
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-12">
           <div class="civic-next-steps__content">
             {% block content_top %}
               {% if content_top is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/02-molecules/next-steps/next-steps.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/02-molecules/next-steps/next-steps.twig
@@ -21,7 +21,7 @@
   <a class="civic-next-steps {{ modifier_class }}" href={{ url }}>
     <div class="container">
       <div class="row">
-        <div class="col-12">
+        <div class="col-xxs-12">
           <div class="civic-next-steps__content">
             {% block content_top %}
               {% if content_top is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/accordion/accordion.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/accordion/accordion.twig
@@ -23,14 +23,14 @@
     <div class="container">
       <div class="row">
         {% if title is not empty %}
-          <div class="civic-accordion__content-top col-xs-12">
+          <div class="civic-accordion__content-top col-12">
             <div class="civic-accordion__title-top">
               {{ title }}
             </div>
           </div>
         {% endif %}
 
-        <div class="civic-accordion__inner col-xs-12">
+        <div class="civic-accordion__inner col-12">
           <ul class="civic-accordion__list" data-multiselectable="true">
             {% for fold in panels %}
               {% if fold.title is not empty or fold.content is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/accordion/accordion.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/accordion/accordion.twig
@@ -23,14 +23,14 @@
     <div class="container">
       <div class="row">
         {% if title is not empty %}
-          <div class="civic-accordion__content-top col-12">
+          <div class="civic-accordion__content-top col-xxs-12">
             <div class="civic-accordion__title-top">
               {{ title }}
             </div>
           </div>
         {% endif %}
 
-        <div class="civic-accordion__inner col-12">
+        <div class="civic-accordion__inner col-xxs-12">
           <ul class="civic-accordion__list" data-multiselectable="true">
             {% for fold in panels %}
               {% if fold.title is not empty or fold.content is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/alert/alert.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/alert/alert.twig
@@ -30,7 +30,7 @@
   <div class="civic-alert {{ modifier_class }}" data-alert-id="{{ id }}" data-alert-type="{{ type }}" data-component-name="civic-alert" role="alert">
     <div class="container">
       <div class="row">
-        <div class="civic-alert__title col-12 col-m-3">
+        <div class="civic-alert__title col-xxs-12 col-m-3">
           {% if icons[type] is defined %}
             <span class="civic-alert__icon">
               {% include "@atoms/icon/icon.twig" with {
@@ -41,7 +41,7 @@
           {% endif %}
           {{ title }}
         </div>
-        <div class="civic-alert__summary col-12 col-m-9">
+        <div class="civic-alert__summary col-xxs-12 col-m-9">
           {{ description|raw }}
           {% include "@atoms/button/button.twig" with {
             kind: 'button',

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/alert/alert.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/alert/alert.twig
@@ -30,7 +30,7 @@
   <div class="civic-alert {{ modifier_class }}" data-alert-id="{{ id }}" data-alert-type="{{ type }}" data-component-name="civic-alert" role="alert">
     <div class="container">
       <div class="row">
-        <div class="civic-alert__title col-xs-12 col-m-3">
+        <div class="civic-alert__title col-12 col-m-3">
           {% if icons[type] is defined %}
             <span class="civic-alert__icon">
               {% include "@atoms/icon/icon.twig" with {
@@ -41,7 +41,7 @@
           {% endif %}
           {{ title }}
         </div>
-        <div class="civic-alert__summary col-xs-12 col-m-9">
+        <div class="civic-alert__summary col-12 col-m-9">
           {{ description|raw }}
           {% include "@atoms/button/button.twig" with {
             kind: 'button',

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/banner/banner.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/banner/banner.twig
@@ -35,7 +35,7 @@
           {% if content_top1 is not empty %}
             <div class="row">
               {%- block content_top1 %}
-                <div class="col-xs-12">
+                <div class="col-12">
                   <div class="civic-banner__content-top">
                     {{- content_top1 -}}
                   </div>
@@ -48,7 +48,7 @@
             <div class="row">
               {% if breadcrumb is not empty %}
                 {%- block breadcrumb %}
-                  <div class="col-xs-12 col-m-6">
+                  <div class="col-12 col-m-6">
                     <div class="civic-banner__breadcrumb">
                       {{- breadcrumb -}}
                     </div>
@@ -58,7 +58,7 @@
 
               {% if content_top2 is not empty %}
                 {%- block content_top2 %}
-                  <div class="col-xs-12 col-m-6">
+                  <div class="col-12 col-m-6">
                     <div class="civic-banner__content-top2">
                       {{- content_top2 -}}
                     </div>
@@ -71,7 +71,7 @@
           {% if content_top3 is not empty %}
             <div class="row">
               {%- block content_top3 %}
-                <div class="col-xs-12">
+                <div class="col-12">
                   <div class="civic-banner__content-top3">
                     {{- content_top3 -}}
                   </div>
@@ -83,7 +83,7 @@
           {% if title is not empty %}
             <div class="row">
               {%- block title %}
-                <div class="{{ featured_image is not empty ? 'col-xs-12 col-m-6':'col-xs-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-12 col-m-6':'col-12 col-m-8' }}">
                   <div class="civic-banner__title">
                     {% include '@atoms/heading/heading.twig' with {
                       content: title,
@@ -98,7 +98,7 @@
           {% if content_middle is not empty %}
             <div class="row">
               {%- block content_middle %}
-                <div class="{{ featured_image is not empty ? 'col-xs-12 col-m-6':'col-xs-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-12 col-m-6':'col-12 col-m-8' }}">
                   <div class="civic-banner__content-middle">
                     {{- content_middle -}}
                   </div>
@@ -110,7 +110,7 @@
           {% if content is not empty %}
             <div class="row">
               {%- block content %}
-                <div class="{{ featured_image is not empty ? 'col-xs-12 col-m-6':'col-xs-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-12 col-m-6':'col-12 col-m-8' }}">
                   <div class="civic-banner__content">
                     {{- content -}}
                   </div>
@@ -139,7 +139,7 @@
       <div class="container">
         <div class="row">
           {%- block content_below %}
-            <div class="col-xs-12">
+            <div class="col-12">
               <div class="civic-banner__content-below">
                 {{- content_below -}}
               </div>
@@ -153,7 +153,7 @@
       <div class="container">
         <div class="row">
           {%- block content_bottom %}
-            <div class="col-xs-12">
+            <div class="col-12">
               <div class="civic-banner__content-bottom">
                 {{- content_bottom -}}
               </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/banner/banner.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/banner/banner.twig
@@ -35,7 +35,7 @@
           {% if content_top1 is not empty %}
             <div class="row">
               {%- block content_top1 %}
-                <div class="col-12">
+                <div class="col-xxs-12">
                   <div class="civic-banner__content-top">
                     {{- content_top1 -}}
                   </div>
@@ -48,7 +48,7 @@
             <div class="row">
               {% if breadcrumb is not empty %}
                 {%- block breadcrumb %}
-                  <div class="col-12 col-m-6">
+                  <div class="col-xxs-12 col-m-6">
                     <div class="civic-banner__breadcrumb">
                       {{- breadcrumb -}}
                     </div>
@@ -58,7 +58,7 @@
 
               {% if content_top2 is not empty %}
                 {%- block content_top2 %}
-                  <div class="col-12 col-m-6">
+                  <div class="col-xxs-12 col-m-6">
                     <div class="civic-banner__content-top2">
                       {{- content_top2 -}}
                     </div>
@@ -71,7 +71,7 @@
           {% if content_top3 is not empty %}
             <div class="row">
               {%- block content_top3 %}
-                <div class="col-12">
+                <div class="col-xxs-12">
                   <div class="civic-banner__content-top3">
                     {{- content_top3 -}}
                   </div>
@@ -83,7 +83,7 @@
           {% if title is not empty %}
             <div class="row">
               {%- block title %}
-                <div class="{{ featured_image is not empty ? 'col-12 col-m-6':'col-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-xxs-12 col-m-6':'col-xxs-12 col-m-8' }}">
                   <div class="civic-banner__title">
                     {% include '@atoms/heading/heading.twig' with {
                       content: title,
@@ -98,7 +98,7 @@
           {% if content_middle is not empty %}
             <div class="row">
               {%- block content_middle %}
-                <div class="{{ featured_image is not empty ? 'col-12 col-m-6':'col-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-xxs-12 col-m-6':'col-xxs-12 col-m-8' }}">
                   <div class="civic-banner__content-middle">
                     {{- content_middle -}}
                   </div>
@@ -110,7 +110,7 @@
           {% if content is not empty %}
             <div class="row">
               {%- block content %}
-                <div class="{{ featured_image is not empty ? 'col-12 col-m-6':'col-12 col-m-8' }}">
+                <div class="{{ featured_image is not empty ? 'col-xxs-12 col-m-6':'col-xxs-12 col-m-8' }}">
                   <div class="civic-banner__content">
                     {{- content -}}
                   </div>
@@ -139,7 +139,7 @@
       <div class="container">
         <div class="row">
           {%- block content_below %}
-            <div class="col-12">
+            <div class="col-xxs-12">
               <div class="civic-banner__content-below">
                 {{- content_below -}}
               </div>
@@ -153,7 +153,7 @@
       <div class="container">
         <div class="row">
           {%- block content_bottom %}
-            <div class="col-12">
+            <div class="col-xxs-12">
               <div class="civic-banner__content-bottom">
                 {{- content_bottom -}}
               </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/callout/callout.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/callout/callout.twig
@@ -24,7 +24,7 @@
 <div class="civic-callout {{ modifier_class }}">
   <div class="container">
     <div class="row">
-      <div class="col-xs-12">
+      <div class="col-12">
         <div class="civic-callout--wrapper">
           {% block content_top %}
             {% if content_top is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/callout/callout.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/callout/callout.twig
@@ -24,7 +24,7 @@
 <div class="civic-callout {{ modifier_class }}">
   <div class="container">
     <div class="row">
-      <div class="col-12">
+      <div class="col-xxs-12">
         <div class="civic-callout--wrapper">
           {% block content_top %}
             {% if content_top is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/card-container/card-container.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/card-container/card-container.twig
@@ -20,7 +20,7 @@
 #}
 
 {% set theme_class = 'civic-theme-%s'|format(theme|default('light')) %}
-{% set column_class = 'col-xs-12 col-m-%s'|format(12 / column_count|default(1)) %}
+{% set column_class = 'col-12 col-m-%s'|format(12 / column_count|default(1)) %}
 {% set fill_width_class = fill_width ? 'civic-card-container--fill-width' : '' %}
 {% set spacing_class = with_spacing ? 'civic-card-container--with-spacing civic-component--with-spacing' : '' %}
 {% set modifier_class = '%s %s %s %s'|format(theme_class, fill_width_class, spacing_class, modifier_class|default('')) %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/card-container/card-container.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/card-container/card-container.twig
@@ -20,7 +20,7 @@
 #}
 
 {% set theme_class = 'civic-theme-%s'|format(theme|default('light')) %}
-{% set column_class = 'col-12 col-m-%s'|format(12 / column_count|default(1)) %}
+{% set column_class = 'col-xxs-12 col-m-%s'|format(12 / column_count|default(1)) %}
 {% set fill_width_class = fill_width ? 'civic-card-container--fill-width' : '' %}
 {% set spacing_class = with_spacing ? 'civic-card-container--with-spacing civic-component--with-spacing' : '' %}
 {% set modifier_class = '%s %s %s %s'|format(theme_class, fill_width_class, spacing_class, modifier_class|default('')) %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/fieldset/fieldset.stories.js
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/fieldset/fieldset.stories.js
@@ -42,5 +42,5 @@ export const Fieldset = () => {
     children: randomFormElements(numOfElements, theme, true).join(''),
   });
 
-  return `<div class="container"><div class="row"><div class="col-xs-12">${html}</div></div></div>`;
+  return `<div class="container"><div class="row"><div class="col-12">${html}</div></div></div>`;
 };

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/fieldset/fieldset.stories.js
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/fieldset/fieldset.stories.js
@@ -42,5 +42,5 @@ export const Fieldset = () => {
     children: randomFormElements(numOfElements, theme, true).join(''),
   });
 
-  return `<div class="container"><div class="row"><div class="col-12">${html}</div></div></div>`;
+  return `<div class="container"><div class="row"><div class="col-xxs-12">${html}</div></div></div>`;
 };

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.stories.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.stories.twig
@@ -88,7 +88,7 @@
   {% endset %}
 
   {%- block content_bottom1 %}
-    <div class="col-12 col-m-7">
+    <div class="col-xxs-12 col-m-7">
       <div class="civic-footer__bottom__content-bottom1">
         {{- content_bottom1 -}}
       </div>
@@ -104,7 +104,7 @@
   {% endset %}
 
   {%- block content_bottom2 %}
-    <div class="col-12 col-m-5">
+    <div class="col-xxs-12 col-m-5">
       <div class="civic-footer__bottom__content-bottom2">
         {{- content_bottom2 -}}
       </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.stories.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.stories.twig
@@ -88,7 +88,7 @@
   {% endset %}
 
   {%- block content_bottom1 %}
-    <div class="col-xs-12 col-m-7">
+    <div class="col-12 col-m-7">
       <div class="civic-footer__bottom__content-bottom1">
         {{- content_bottom1 -}}
       </div>
@@ -104,7 +104,7 @@
   {% endset %}
 
   {%- block content_bottom2 %}
-    <div class="col-xs-12 col-m-5">
+    <div class="col-12 col-m-5">
       <div class="civic-footer__bottom__content-bottom2">
         {{- content_bottom2 -}}
       </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.twig
@@ -30,7 +30,7 @@
 
           {% if content_top1 is not empty %}
             {%- block content_top1 %}
-              <div class="col-xs-12 col-m-6">
+              <div class="col-12 col-m-6">
                 <div class="civic-footer__top__content-top1">
                   {{- content_top1 -}}
                 </div>
@@ -40,7 +40,7 @@
 
           {% if content_top2 is not empty %}
             {%- block content_top2 %}
-              <div class="col-xs-12 col-m-6">
+              <div class="col-12 col-m-6">
                 <div class="civic-footer__top__content-top2">
                   {{- content_top2 -}}
                 </div>
@@ -58,7 +58,7 @@
 
           {% if content_middle1 is not empty %}
             {%- block content_middle1 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-12 col-m-3">
                 <div class="civic-footer__middle__content-middle1">
                   {{- content_middle1 -}}
                 </div>
@@ -68,7 +68,7 @@
 
           {% if content_middle2 is not empty %}
             {%- block content_middle2 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-12 col-m-3">
                 <div class="civic-footer__middle__content-middle2">
                   {{- content_middle2 -}}
                 </div>
@@ -78,7 +78,7 @@
 
           {% if content_middle3 is not empty %}
             {%- block content_middle3 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-12 col-m-3">
                 <div class="civic-footer__middle__content-middle3">
                   {{- content_middle3 -}}
                 </div>
@@ -88,7 +88,7 @@
 
           {% if content_middle4 is not empty %}
             {%- block content_middle4 %}
-              <div class="col-xs-12 col-m-3">
+              <div class="col-12 col-m-3">
                 <div class="civic-footer__middle__content-middle4">
                   {{- content_middle4 -}}
                 </div>
@@ -106,7 +106,7 @@
 
           {% if content_bottom1 is not empty %}
             {%- block content_bottom1 %}
-              <div class="col-xs-12 col-m-7">
+              <div class="col-12 col-m-7">
                 <div class="civic-footer__bottom__content-bottom1">
                   {{- content_bottom1 -}}
                 </div>
@@ -116,7 +116,7 @@
 
           {% if content_bottom2 is not empty %}
             {%- block content_bottom2 %}
-              <div class="col-xs-12 col-m-5">
+              <div class="col-12 col-m-5">
                 <div class="civic-footer__bottom__content-bottom2">
                   {{- content_bottom2 -}}
                 </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/footer/footer.twig
@@ -30,7 +30,7 @@
 
           {% if content_top1 is not empty %}
             {%- block content_top1 %}
-              <div class="col-12 col-m-6">
+              <div class="col-xxs-12 col-m-6">
                 <div class="civic-footer__top__content-top1">
                   {{- content_top1 -}}
                 </div>
@@ -40,7 +40,7 @@
 
           {% if content_top2 is not empty %}
             {%- block content_top2 %}
-              <div class="col-12 col-m-6">
+              <div class="col-xxs-12 col-m-6">
                 <div class="civic-footer__top__content-top2">
                   {{- content_top2 -}}
                 </div>
@@ -58,7 +58,7 @@
 
           {% if content_middle1 is not empty %}
             {%- block content_middle1 %}
-              <div class="col-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civic-footer__middle__content-middle1">
                   {{- content_middle1 -}}
                 </div>
@@ -68,7 +68,7 @@
 
           {% if content_middle2 is not empty %}
             {%- block content_middle2 %}
-              <div class="col-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civic-footer__middle__content-middle2">
                   {{- content_middle2 -}}
                 </div>
@@ -78,7 +78,7 @@
 
           {% if content_middle3 is not empty %}
             {%- block content_middle3 %}
-              <div class="col-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civic-footer__middle__content-middle3">
                   {{- content_middle3 -}}
                 </div>
@@ -88,7 +88,7 @@
 
           {% if content_middle4 is not empty %}
             {%- block content_middle4 %}
-              <div class="col-12 col-m-3">
+              <div class="col-xxs-12 col-m-3">
                 <div class="civic-footer__middle__content-middle4">
                   {{- content_middle4 -}}
                 </div>
@@ -106,7 +106,7 @@
 
           {% if content_bottom1 is not empty %}
             {%- block content_bottom1 %}
-              <div class="col-12 col-m-7">
+              <div class="col-xxs-12 col-m-7">
                 <div class="civic-footer__bottom__content-bottom1">
                   {{- content_bottom1 -}}
                 </div>
@@ -116,7 +116,7 @@
 
           {% if content_bottom2 is not empty %}
             {%- block content_bottom2 %}
-              <div class="col-12 col-m-5">
+              <div class="col-xxs-12 col-m-5">
                 <div class="civic-footer__bottom__content-bottom2">
                   {{- content_bottom2 -}}
                 </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/form-element/form-element.stories.js
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/form-element/form-element.stories.js
@@ -189,5 +189,5 @@ export const FormElement = () => {
     children,
   });
 
-  return `<div class="container"><div class="row"><div class="col-12">${html}</div></div></div>`;
+  return `<div class="container"><div class="row"><div class="col-xxs-12">${html}</div></div></div>`;
 };

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/form-element/form-element.stories.js
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/form-element/form-element.stories.js
@@ -189,5 +189,5 @@ export const FormElement = () => {
     children,
   });
 
-  return `<div class="container"><div class="row"><div class="col-xs-12">${html}</div></div></div>`;
+  return `<div class="container"><div class="row"><div class="col-12">${html}</div></div></div>`;
 };

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/listing/listing.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/listing/listing.twig
@@ -43,7 +43,7 @@
       <header class="civic-listing__header" tabindex="0">
         <div class="container">
           <div class="row">
-            <div class="col-12">
+            <div class="col-xxs-12">
               {{ header }}
             </div>
           </div>
@@ -65,7 +65,7 @@
       <div class="civic-listing__empty-results">
         <div class="container">
           <div class="row">
-            <div class="col-12">
+            <div class="col-xxs-12">
               {{ empty }}
             </div>
           </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/listing/listing.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/listing/listing.twig
@@ -43,7 +43,7 @@
       <header class="civic-listing__header" tabindex="0">
         <div class="container">
           <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
               {{ header }}
             </div>
           </div>
@@ -65,7 +65,7 @@
       <div class="civic-listing__empty-results">
         <div class="container">
           <div class="row">
-            <div class="col-xs-12">
+            <div class="col-12">
               {{ empty }}
             </div>
           </div>

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/slider/slider.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/slider/slider.twig
@@ -21,7 +21,7 @@
   <div class="civic-slider {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-12">
+        <div class="col-xxs-12">
           <div class="civic-slider__container" data-component-civic-slider>
             {% block top_controls %}
               {% if title is not empty or link is not empty %}

--- a/docroot/themes/contrib/civic/civic-library/components/03-organisms/slider/slider.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/03-organisms/slider/slider.twig
@@ -21,7 +21,7 @@
   <div class="civic-slider {{ modifier_class }}">
     <div class="container">
       <div class="row">
-        <div class="col-xs-12">
+        <div class="col-12">
           <div class="civic-slider__container" data-component-civic-slider>
             {% block top_controls %}
               {% if title is not empty or link is not empty %}

--- a/docroot/themes/contrib/civic/templates/media/media--civic-image--component.html.twig
+++ b/docroot/themes/contrib/civic/templates/media/media--civic-image--component.html.twig
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="col-xs-12">
+  <div class="col-12">
     {% include '@molecules/figure/figure.twig' %}
   </div>
 </div>

--- a/docroot/themes/contrib/civic/templates/media/media--civic-image--component.html.twig
+++ b/docroot/themes/contrib/civic/templates/media/media--civic-image--component.html.twig
@@ -1,5 +1,5 @@
 <div class="container">
-  <div class="col-12">
+  <div class="col-xxs-12">
     {% include '@molecules/figure/figure.twig' %}
   </div>
 </div>

--- a/docroot/themes/contrib/civic/templates/views/views-view.html.twig
+++ b/docroot/themes/contrib/civic/templates/views/views-view.html.twig
@@ -48,7 +48,7 @@
     <header class="civic-listing__header" tabindex="0">
       <div class="container">
         <div class="row">
-          <div class="col-12">
+          <div class="col-xxs-12">
             {{ header }}
           </div>
         </div>

--- a/docroot/themes/contrib/civic/templates/views/views-view.html.twig
+++ b/docroot/themes/contrib/civic/templates/views/views-view.html.twig
@@ -48,7 +48,7 @@
     <header class="civic-listing__header" tabindex="0">
       <div class="container">
         <div class="row">
-          <div class="col-xs-12">
+          <div class="col-12">
             {{ header }}
           </div>
         </div>


### PR DESCRIPTION
I have noticed many components are using .col-xs-12 instead of .col-xxs-12 which causes screens smaller than xs to receive extra padding (mis-aligning) because they aren’t getting any column styles. 

<!--
Please follow these rules:
1. SUBJECT: use format [PRJ-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below.

3. CONFLICTS: Make sure that there are no conflicts in your PR. Resolve them before submitting PR for review.

4. COMMENTS: Scan through your PR yourself and comment on the lines that does not look clear enough. This will save SIGNIFICANT time for reviewer to approve the PR.

5. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

6. ASSIGNEE: Assign at least 2 reviewers.     

7. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**Issue URL:**

### Changed
<!--
Provide a list of what was added/changed/removed etc. 

Start with a verb so that it is clear what has happened:Added/ Updated/Removed/Refactored etc.

Also, explain WHY something was done if this was not a normal implementation.
-->
1. Changed all instances of .col-xs-12 to .col-xxs-12

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
The following example shows an instance of this misalignment on xxs screens when a col-xs-12 was applied. The "Summary" heading is not in a column/row/container, but the Summary below is in a div with col-xs-12 instead of col-xxs-12. The after demonstrates the change to use col-xxs-12.

**Example before**
<img width="397" alt="Screen Shot 2022-03-24 at 10 32 38 am" src="https://user-images.githubusercontent.com/520440/159818670-1daeb481-1db7-4cb2-99a4-3bd60f5fce90.png">

**Example after**
<img width="392" alt="Screen Shot 2022-03-24 at 10 32 53 am" src="https://user-images.githubusercontent.com/520440/159818664-7a8e1ad7-db64-4ecd-adcf-7ccd5f2b25f8.png">



