### PR TITLE
Added support for icon size on buttons that is different to button size.

### DIFF
--- a/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.stories.js
+++ b/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.stories.js
@@ -98,7 +98,7 @@ export const Button = (knobTab) => {
         Regular: 'regular',
         Small: 'small',
         'Extra Small': 'extra-small',
-        Default: '',
+        None: '',
       },
       'regular',
       iconKnobTab,

--- a/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.stories.js
+++ b/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.stories.js
@@ -91,6 +91,18 @@ export const Button = (knobTab) => {
       'after',
       iconKnobTab,
     ) : null,
+    icon_size: withIcon ? radios(
+      'Icon Size', {
+        'Extra Large': 'extra-large',
+        Large: 'large',
+        Regular: 'regular',
+        Small: 'small',
+        'Extra Small': 'extra-small',
+        Default: '',
+      },
+      'regular',
+      iconKnobTab,
+    ) : null,
   };
 
   return CivicButton({ ...generalKnobs, ...iconKnobs });

--- a/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.twig
@@ -9,7 +9,7 @@
  * - size: [string] Button size: large, regular, small.
  * - icon: [boolean] Button icon visibility: true, false.
  * - icon_placement: [string] Icon position: left, right
- * - icon_size: [string] Icon size: small, medium, large
+ * - icon_size: [string] Icon size: large, regular, small.
  * - text: [string] Button text.
  * - title: [string] Button title.
  * - url: [string] URL for the link button.
@@ -29,6 +29,7 @@
 {% set type = type in ['primary', 'secondary', 'tertiary', 'chip'] ? type : null %}
 {% set size = size in ['extra-large', 'large', 'regular', 'small', 'extra-small'] ? size : 'regular' %}
 {% set icon_placement = icon_placement in ['before', 'after'] ? icon_placement : 'after' %}
+{% set icon_size = icon_size in ['large', 'regular', 'small'] ? icon_size : size %}
 
 {% set theme_class = 'civic-theme-%s'|format(theme|default('light')) %}
 {% set type_class = type ? 'civic-button--%s'|format(type) : '' %}
@@ -41,7 +42,7 @@
     <span class="civic-button__icon">
 		  {% include '@atoms/icon/icon.twig' with {
         symbol: icon,
-        size: size,
+        size: icon_size,
       } only %}
 		</span>
   {% endif %}

--- a/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.twig
+++ b/docroot/themes/contrib/civic/civic-library/components/01-atoms/button/button.twig
@@ -6,10 +6,10 @@
  * Variables:
  * - kind: [string] Button kind: submit, reset, button, link, checkbox, radio.
  * - type: [string] Button type: primary, primary, secondary, tertiary, chip.
- * - size: [string] Button size: large, regular, small.
+ * - size: [string] Button size: extra-large, large, regular, small, extra-small.
  * - icon: [boolean] Button icon visibility: true, false.
  * - icon_placement: [string] Icon position: left, right
- * - icon_size: [string] Icon size: large, regular, small.
+ * - icon_size: [string] Icon size: extra-large, large, regular, small, extra-small.
  * - text: [string] Button text.
  * - title: [string] Button title.
  * - url: [string] URL for the link button.
@@ -29,7 +29,7 @@
 {% set type = type in ['primary', 'secondary', 'tertiary', 'chip'] ? type : null %}
 {% set size = size in ['extra-large', 'large', 'regular', 'small', 'extra-small'] ? size : 'regular' %}
 {% set icon_placement = icon_placement in ['before', 'after'] ? icon_placement : 'after' %}
-{% set icon_size = icon_size in ['large', 'regular', 'small'] ? icon_size : size %}
+{% set icon_size = icon_size in ['extra-large', 'large', 'regular', 'small', 'extra-small'] ? icon_size : size %}
 
 {% set theme_class = 'civic-theme-%s'|format(theme|default('light')) %}
 {% set type_class = type ? 'civic-button--%s'|format(type) : '' %}
@@ -65,7 +65,7 @@
     {{ button_text }}<span class="civic-button__external">
     {% include '@atoms/icon/icon.twig' with {
       symbol: 'arrows_upperrightarrow',
-      size: size,
+      size: icon_size,
     } only %}
     </span>
   {% else %}
@@ -78,7 +78,7 @@
     {{ button_text }}<span class="civic-button__dismiss" data-button-dismiss>
     {% include '@atoms/icon/icon.twig' with {
       symbol: 'userinterface_cancel',
-      size: size,
+      size: icon_size,
     } only %}
     </span>
   {% else %}


### PR DESCRIPTION
<!--
Please follow these rules:
1. SUBJECT: use format [PRJ-123] Verb in past tense with dot at the end.
   - This subject will be used as a commit message after PR is merged.
   - Verbs are usually one of these: Updated, Refactored, Removed, Changed, Added.
   - If there is no ticket - do not put [NOTICKET].

2. BODY: fill-in the template below.

3. CONFLICTS: Make sure that there are no conflicts in your PR. Resolve them before submitting PR for review.

4. COMMENTS: Scan through your PR yourself and comment on the lines that does not look clear enough. This will save SIGNIFICANT time for reviewer to approve the PR.

5. LABEL: Assign 'Needs review' label as soon as you ready to have this reviewed.

6. ASSIGNEE: Assign at least 2 reviewers.     

7. SLACK: Post a link to this PR to #developers channel.

No need to remove these lines - they are comments.
-->

**Issue URL:**

### Changed
<!--
Provide a list of what was added/changed/removed etc. 

Start with a verb so that it is clear what has happened:Added/ Updated/Removed/Refactored etc.

Also, explain WHY something was done if this was not a normal implementation.
-->
1.  Set the button icon size parameter to use the icon_size variable instead of the button's own size variable. If an icon_size is not set for the button, the icon size matches the button size.
2. Fixed documentation in button variables for icon size.

### Screenshots

<!--
Provide as many screenshots as required to make reviewers understand what was changed.
-->
<img width="1824" alt="Screen Shot 2022-04-20 at 4 10 59 pm" src="https://user-images.githubusercontent.com/520440/164162155-7a3aa97b-bea3-4ef0-9b67-a155777a4a65.png">
<img width="1824" alt="Screen Shot 2022-04-20 at 4 10 34 pm" src="https://user-images.githubusercontent.com/520440/164162187-8b873382-2c5b-4f37-8f8d-81f39bfb994c.png">

Changed "Default" back to "None" after screenshotting.